### PR TITLE
feat: add rate limiting to command handlers

### DIFF
--- a/backend/src/commands/clear-all-command-handler.ts
+++ b/backend/src/commands/clear-all-command-handler.ts
@@ -1,8 +1,14 @@
 import { CommandHandler, ExecuteParams } from '@/commands/command'
+import { RateLimitConfig } from '@/helpers/rate-limit'
 import { CommandError, CommandErrorCode } from '@/types/errors'
 
 export class ClearAllCommandHandler extends CommandHandler {
   private readonly regex = /^!clearall\s*$/i
+
+  rateLimit: RateLimitConfig = {
+    windowMs: 5000,
+    max: 3,
+  }
 
   public canHandle(messageText: string): boolean {
     return this.regex.test(messageText)

--- a/backend/src/commands/fill-command-handler.ts
+++ b/backend/src/commands/fill-command-handler.ts
@@ -4,9 +4,15 @@ import { CommandHandler, ExecuteParams } from '@/commands/command'
 import { MAX_VIDEO_DURATION_SECONDS, MIN_VIDEO_DURATION_SECONDS } from '@/config/video'
 import { SongMetadata } from '@/data/get-video-metadata'
 import { innertube } from '@/data/innertube'
+import { RateLimitConfig } from '@/helpers/rate-limit'
 
 export class FillCommandHandler extends CommandHandler {
   private readonly regex = /^!fill\s+(.+)$/i
+
+  rateLimit: RateLimitConfig = {
+    windowMs: 5000,
+    max: 3,
+  }
 
   public canHandle(messageText: string): boolean {
     return this.regex.test(messageText)

--- a/backend/src/commands/playlist-command-handler.ts
+++ b/backend/src/commands/playlist-command-handler.ts
@@ -4,10 +4,16 @@ import { CommandHandler, ExecuteParams } from '@/commands/command'
 import { MAX_VIDEO_DURATION_SECONDS } from '@/config/video'
 import { SongMetadata } from '@/data/get-video-metadata'
 import { innertube } from '@/data/innertube'
+import { RateLimitConfig } from '@/helpers/rate-limit'
 
 export class PlaylistCommandHandler extends CommandHandler {
   private readonly regex = /^!playlist\s+(.+)$/i
   private readonly urlRegex = /[?&]list=([^#\&\?]+)/
+
+  rateLimit: RateLimitConfig = {
+    windowMs: 5000,
+    max: 3,
+  }
 
   public canHandle(messageText: string): boolean {
     return this.regex.test(messageText)

--- a/backend/src/commands/remove-command-handler.ts
+++ b/backend/src/commands/remove-command-handler.ts
@@ -1,8 +1,14 @@
 import { CommandHandler, ExecuteParams } from '@/commands/command'
+import { RateLimitConfig } from '@/helpers/rate-limit'
 import { CommandError, CommandErrorCode } from '@/types/errors'
 
 export class RemoveCommandHandler extends CommandHandler {
   private readonly regex = /^!remove\s([1-9][0-9]?)$/
+
+  rateLimit: RateLimitConfig = {
+    windowMs: 5000,
+    max: 3,
+  }
 
   public canHandle(command: string): boolean {
     return this.regex.test(command)

--- a/backend/src/commands/seek-command-handler.ts
+++ b/backend/src/commands/seek-command-handler.ts
@@ -1,8 +1,14 @@
 import { CommandHandler, ExecuteParams } from '@/commands/command'
+import { RateLimitConfig } from '@/helpers/rate-limit'
 import { CommandError, CommandErrorCode } from '@/types/errors'
 
 export class SeekCommandHandler extends CommandHandler {
   private readonly regex = /^!seek\s+(?:(\d{1,2}):([0-5]?\d)|(\d{1,3}))$/
+
+  rateLimit: RateLimitConfig = {
+    windowMs: 5000,
+    max: 3,
+  }
 
   public canHandle(command: string): boolean {
     return this.regex.test(command)

--- a/backend/src/commands/shuffle-command-handler.ts
+++ b/backend/src/commands/shuffle-command-handler.ts
@@ -1,8 +1,14 @@
 import { CommandHandler, ExecuteParams } from '@/commands/command'
+import { RateLimitConfig } from '@/helpers/rate-limit'
 import { CommandError, CommandErrorCode } from '@/types/errors'
 
 export class ShuffleCommandHandler extends CommandHandler {
   private readonly regex = /^!shuffle$/
+
+  rateLimit: RateLimitConfig = {
+    windowMs: 5000,
+    max: 3,
+  }
 
   public canHandle(command: string): boolean {
     return this.regex.test(command)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rate-limiting configuration has been added to command handlers. Commands are now limited to 3 requests per 5-second window. Rate-limiting has been consistently applied across all command handlers to ensure uniform behavior and stable operation. Users may experience request throttling when command limits are exceeded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->